### PR TITLE
apple keyboard function keys

### DIFF
--- a/.spacemacs
+++ b/.spacemacs
@@ -32,7 +32,7 @@ This function should only modify configuration layer settings."
 
    ;; List of configuration layers to load.
    dotspacemacs-configuration-layers
-   '(
+   '(systemd
      (typescript :variables
                  typescript-indent-level 2
                  typescript-backend 'lsp

--- a/apple.kbd
+++ b/apple.kbd
@@ -11,25 +11,21 @@
   fallthrough true
 )
 
-;; Below, I use `around' to compose `layer-toggle' with `fn' (instead
-;; of using `layer-toggle' directly) so that the `fn' keypress
-;; actually gets emitted. This matters when using an application that
-;; can use `fn' as a modifier (like Emacs).
-
 (defsrc
-  esc  f1   f2   f3   f4   f5   f6   f7   f8   f9   f10  f11  f12        f13  f14  f15   f16  f17  f18  f19
-  grv  1    2    3    4    5    6    7    8    9    0    -    =    bspc  ins  home pgup  nlck =    kp/  kp*
-  tab  q    w    e    r    t    y    u    i    o    p    [    ]    \     del  end  pgdn  kp7  kp8  kp9  kp-
-  caps a    s    d    f    g    h    j    k    l    ;    '    ret                        kp4  kp5  kp6  kp+
-  lsft z    x    c    v    b    n    m    ,    .    /    rsft                 up         kp1  kp2  kp3  kprt
-  lctl lalt lmet           spc                 rmet ralt rctl            left down rght  kp0       kp.
+  esc  brdn brup zoom find micm zzz  prev pp   next mute vold volu menu    f13 f14 f15   f16  f17  f18  f19
+  grv  1    2    3    4    5    6    7    8    9    0    -    =    bspc    fn   home pgup   nlck =    kp/  kp*
+  tab  q    w    e    r    t    y    u    i    o    p    [    ]    \       del  end  pgdn   kp7  kp8  kp9  kp-
+  caps a    s    d    f    g    h    j    k    l    ;    '    ret                           kp4  kp5  kp6  kp+
+  lsft z    x    c    v    b    n    m    ,    .    /    rsft                   up          kp1  kp2  kp3  kprt
+  lctl lalt lmet           spc                 rmet ralt rctl              left down rght   kp0       kp.
 )
 
 (deflayer default
-  esc  f1   f2   f3   f4   f5   f6   f7   f8   f9   f10  f11  f12        f13  f14  f15   f16  f17  f18  f19
-  grv  1    2    3    4    5    6    7    8    9    0    -    =    bspc  ins  home pgup  nlck =    kp/  kp*
-  tab  q    w    e    r    t    y    u    i    o    p    [    ]    \     del  end  pgdn  kp7  kp8  kp9  kp-
-  lctl a    s    d    f    g    h    j    k    l    ;    '    ret                        kp4  kp5  kp6  kp+
-  lsft z    x    c    v    b    n    m    ,    .    /    rsft                 up         kp1  kp2  kp3  kprt
-  lctl lalt lmet           spc                 rmet ralt rctl            left down rght  kp0       kp.
+  esc  f1   f2   f3   f4   f5   f6   f7   f8   f9   f10  f11  f12  menu    f13  f14  f15    f16  f17  f18  f19
+  grv  1    2    3    4    5    6    7    8    9    0    -    =    bspc    fn   home pgup   nlck =    kp/  kp*
+  tab  q    w    e    r    t    y    u    i    o    p    [    ]    \       del  end  pgdn   kp7  kp8  kp9  kp-
+  lctl a    s    d    f    g    h    j    k    l    ;    '    ret                           kp4  kp5  kp6  kp+
+  lsft z    x    c    v    b    n    m    ,    .    /    rsft                   up          kp1  kp2  kp3  kprt
+  lctl lalt lmet           spc                 rmet ralt rctl              left down rght   kp0       kp.
 )
+


### PR DESCRIPTION
Changed the KMonad source code a little bit, to properly handle function keys on PC Linux with Apple Magic Keyboard. 
Unfortunately I cannot use the FN key yet, due to the two-byte format on MacOS. I would need to really get into the guts of KMonad and merge the Windows/Linux/MacOS Type.hs and handlers.